### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,4 +4,5 @@ author=Electronic Sweet Peas
 maintainer=Electronic Sweet Peas <info@sweetpeas.se>
 sentence=Support library for the light sensor OPT3001 from Texas Instruments
 paragraph=This library offers basic support for the OPT3001 light sensor. It provides basic access to registers as well as a method for getting a normalized result back from the device.
+category=Sensors
 url=


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library Opt3001 is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
